### PR TITLE
remove sys.path update for imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,5 @@
 import os
-import sys
-import argparse
 from lightning import LightningApp, LightningFlow, CloudCompute
-
-sys.path.insert(0, os.path.dirname(__file__))
 
 from quick_start.components import PyTorchLightningScript, ServeScript
 from quick_start.train.train import train_script_path


### PR DESCRIPTION
After https://github.com/PyTorchLightning/lightning/pull/474 lands, the manual `sys.path.insert` is no longer needed to run the app. 