### PR TITLE
Fix bug when logdir has spaces

### DIFF
--- a/quick_start/components.py
+++ b/quick_start/components.py
@@ -33,7 +33,7 @@ class PyTorchLightningScript(TracerPythonScript):
                 self._work = work
 
             def on_train_start(self, trainer, *_):
-                cmd = f"tensorboard --logdir={trainer.logger.log_dir} --host {self._work.host} --port {self._work.port}"
+                cmd = f"tensorboard --logdir='{trainer.logger.log_dir}' --host {self._work.host} --port {self._work.port}"
                 self._work._process = Popen(cmd.split(" "))
 
         def trainer_pre_fn(self, *args, work=None, **kwargs):


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

Fixes an issue with launching tensorboard when the log dir has spaces. 

`--logdir path/to/logdir`

vs

`--logdir path/to/log dir` (invalid)

Now, we are wrapping it with quotes. 

Fixes https://linear.app/gridai/issue/LAI2-9329/bug-running-quick-start

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
