### PR TITLE
Bump dependencies

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include *.py
 include *.txt
 exclude *.lightning
 exclude *.gridignore
+exclude *.lightningignore
 exclude *wandb*
 recursive-exclude quick_start *.gridignore
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-torchvision<=0.12.0
+torchvision<=0.15.1
 jsonargparse[signatures]
-wandb==0.12.16
-gradio==2.9.4
-pyyaml==5.4.0
+wandb<=0.14.0
+gradio<=3.23.0
+pyyaml<=6.0
 protobuf<4.21.0  # 4.21 breaks with wandb, tensorboard, or pytorch-lightning: https://github.com/protocolbuffers/protobuf/issues/10048
 websockets
 lightning

--- a/tests/integration_app/app.py
+++ b/tests/integration_app/app.py
@@ -10,7 +10,7 @@ class RootFlow(LightningFlow):
         super().__init__()
 
     def run(self):
-        from lightning.components.demo import PyTorchLightningScript, ImageServeGradio
+        from lightning.app.components.demo import PyTorchLightningScript, ImageServeGradio
         print(PyTorchLightningScript)
         print(ImageServeGradio)
         exit(0)

--- a/tests/test_lightning_integration.py
+++ b/tests/test_lightning_integration.py
@@ -1,4 +1,4 @@
-from lightning.cli.lightning_cli import run_app
+from lightning.app.cli.lightning_cli import run_app
 from click.testing import CliRunner
 
 


### PR DESCRIPTION
This bumps the dependencies, notably torchvision which currently causes torch to be downgraded and re-installed on the the Lightning AI platform. It forces torch=1.11 to be installed, and the download and re-installation can take a long time. 

By bumping the version, we allow the environment to use the preinstalled torch 2.0.0. 

I verified these changes also locally in a fresh environment. 
